### PR TITLE
Download VRAM in BMP Image Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+catflap

--- a/CCaetla.h
+++ b/CCaetla.h
@@ -73,6 +73,7 @@ public:
 	int             ReceiveVRAM(char *, int, int, int, int, int);
 	int             ReceiveVRAM(FILE *, int, int, int, int, int);
 	int             ReceiveVRAMtoFile(int, int, int, int, int);
+	int             ReceiveVRAMBMPtoFile(int, int, int, int, int);
 	int             SendVRAM(char *, int, int, int, int, int);
 	int             SendVRAM(FILE *, int, int, int, int, int);
 

--- a/CatFlap.cpp
+++ b/CatFlap.cpp
@@ -660,6 +660,8 @@ int CmdCallback_Help(int argc, char *argv[]) {
 	        " * VRAM TRANSFER COMMANDS:\n"
 	        "   vup [filename] [x] [y] [w] [h] [depth]\tUpload file to PSX VRAM\n"
 	        "   vdown [filename] [x] [y] [w] [h] [depth]\tDownload file from PSX VRAM\n"
+			"\n"
+			"      VDOWN with a filename of \"*.BMP\" to save VRAM in BMP format.\n"
 	        "\n"
 	        " * MEMORY CARD COMMANDS:\n"
 	        "   mclist [slot]\t\t\t\tList Contents of Memory Card\n"

--- a/bmpFile.h
+++ b/bmpFile.h
@@ -1,0 +1,21 @@
+typedef struct tagBITMAPFILEHEADER {
+	uint16	bfType;
+	uint32	bfSize;
+	uint16	bfReserved1;
+	uint16	bfReserved2;
+	uint32	bfOffBits;
+} __attribute__((packed)) __attribute__((aligned(2))) BITMAPFILEHEADER;
+
+typedef struct tagBITMAPINFOHEADER{
+	uint32	biSize;
+	uint32	biWidth;
+	uint32	biHeight;
+	uint16	biPlanes;
+	uint16	biBitCount;
+	uint32	biCompression;
+	uint32	biSizeImage;
+	uint32	biXPelsPerMeter;
+	uint32	biYPelsPerMeter;
+	uint32	biClrUsed;
+	uint32	biClrImportant;
+} __attribute__((packed)) __attribute__((aligned(2))) BITMAPINFOHEADER;


### PR DESCRIPTION
In the original CatFlap, you could download VRAM and save it as a BMP file by affixing `.bmp` to your filename. I just wanted to add that feature back into C4L as it's an amazing port and I felt it was just missing this one feature.

I've just copied the code out of the CatFlap source and adapted it to Linux.

(oh, and there's a `.gitignore` if you want it)

Cheers, and thank you for your awesome work on C4L!